### PR TITLE
Make Provider middleware idempotent

### DIFF
--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -24,3 +24,24 @@ test('.create works', t => {
     t.end();
   });
 });
+
+test('idempotency with wrapped middleware', async t => {
+  let called = 0;
+  class Foo {
+    foo() {}
+  }
+  const plugin = ReactPlugin.create('foo', {
+    middleware: () => () => {
+      called += 1;
+    },
+  });
+  const middleware = plugin.middleware({}, new Foo());
+  const middleware2 = plugin.middleware({}, new Foo());
+  const element = React.createElement('div');
+  const ctx = {element};
+  middleware(ctx, () => Promise.resolve());
+  middleware2(ctx, () => Promise.resolve());
+
+  t.equals(called, 2, 'called two times');
+  t.end();
+});

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,11 +9,12 @@ import Provider from './provider';
 
 export default {
   create: (name, plugin, provider) => {
-    let originalMiddleware = plugin.middleware;
+    let originalMiddlewareGetter = plugin.middleware;
+    let originalMiddleware = null;
     const ProviderComponent = provider || Provider.create(name);
     plugin.middleware = (deps, provides) => {
-      if (originalMiddleware) {
-        originalMiddleware = originalMiddleware(deps, provides);
+      if (originalMiddlewareGetter && originalMiddleware === null) {
+        originalMiddleware = originalMiddlewareGetter(deps, provides);
       }
       return function(ctx, next) {
         if (ctx.element) {


### PR DESCRIPTION
Simulation tests will currently call middleware functions several times in a row. This middleware fails due to changing originalMiddleware, and is not idempotent. This should allow us to call this middleware several times with the same result.

The issue is seen in the simulation tests added here: https://github.com/fusionjs/fusion-cli/pull/302