### PR TITLE
Call componentWillUnmount in the browser

### DIFF
--- a/src/async/__tests__/index.browser.js
+++ b/src/async/__tests__/index.browser.js
@@ -1,0 +1,54 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-disable react/no-multi-comp */
+import tape from 'tape-cup';
+import React, {Component} from 'react';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {prepare} from '../../index.js';
+
+Enzyme.configure({adapter: new Adapter()});
+tape('Preparing in the browser with componentWillUnmount', t => {
+  let numConstructors = 0;
+  let numRenders = 0;
+  let numChildRenders = 0;
+  let numUnmount = 0;
+  class SimpleComponent extends Component<any> {
+    constructor(props, context) {
+      super(props, context);
+      t.equal(
+        context.__IS_PREPARE__,
+        true,
+        'sets __IS_PREPARE__ to true in context'
+      );
+      numConstructors++;
+    }
+    componentWillUnmount() {
+      numUnmount++;
+    }
+    render() {
+      numRenders++;
+      return <SimplePresentational />;
+    }
+  }
+  function SimplePresentational() {
+    numChildRenders++;
+    return <div>Hello World</div>;
+  }
+  const app = <SimpleComponent />;
+  const p = prepare(app);
+  t.ok(p instanceof Promise, 'prepare returns a promise');
+  p.then(() => {
+    t.equal(numConstructors, 1, 'constructs SimpleComponent once');
+    t.equal(numRenders, 1, 'renders SimpleComponent once');
+    t.equal(numChildRenders, 1, 'renders SimplePresentational once');
+    t.equal(numUnmount, 1, 'calls componentWillUnmount in browser');
+    t.end();
+  });
+});

--- a/src/async/prepare.js
+++ b/src/async/prepare.js
@@ -62,6 +62,9 @@ function prepareElement(element, context) {
   const instance = new CompositeComponent(props, context);
   instance.props = props;
   instance.context = context;
+  if (instance.componentWillUnmount && __BROWSER__) {
+    context.__UNMOUNTS__.push(() => instance.componentWillUnmount());
+  }
   return prepareComponentInstance(instance).then(prepareConfig => {
     // Stop traversing if the component is defer or boundary
     if (prepareConfig.defer || prepareConfig.boundary) {
@@ -83,8 +86,12 @@ function _prepare(element, context) {
 
 function prepare(element: any, context: any = {}) {
   context.__IS_PREPARE__ = true;
+  context.__UNMOUNTS__ = [];
   return _prepare(element, context).then(() => {
     context.__IS_PREPARE__ = false;
+    context.__UNMOUNTS__.forEach(fn => {
+      return fn();
+    });
   });
 }
 


### PR DESCRIPTION
Some components in the browser set up long lived listeners, connections, etc, that need to be cleaned up when the component is unmounted. For example, react-router will listen on the history object. We should call the componentWillUnmount to ensure that anything created during the prepare cycle is cleaned up.