### PR TITLE
Show a better error if `prepare` encounters invalid React element

### DIFF
--- a/src/async/utils/__tests__/isReactCompositeComponent.node.js
+++ b/src/async/utils/__tests__/isReactCompositeComponent.node.js
@@ -1,0 +1,27 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import tape from 'tape-cup';
+import isReactCompositeComponent from '../isReactCompositeComponent.js';
+
+tape('isReactCompositeComponent', async t => {
+  class Yes {
+    render() {}
+  }
+  class No {}
+  const fn = function() {};
+  const arrow = () => {};
+  t.ok(isReactCompositeComponent(Yes));
+  t.ok(!isReactCompositeComponent(No));
+  t.ok(!isReactCompositeComponent(fn));
+  t.ok(!isReactCompositeComponent(arrow));
+  t.ok(!isReactCompositeComponent(''));
+  t.ok(!isReactCompositeComponent(null));
+  t.ok(!isReactCompositeComponent(undefined));
+  t.end();
+});

--- a/src/async/utils/__tests__/isReactFunctionalComponent.node.js
+++ b/src/async/utils/__tests__/isReactFunctionalComponent.node.js
@@ -1,0 +1,25 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import tape from 'tape-cup';
+import isReactFunctionalComponent from '../isReactFunctionalComponent.js';
+
+tape('isReactFunctionalComponent', async t => {
+  class Comp {
+    render() {}
+  }
+  const fn = function() {};
+  const arrow = () => {};
+  t.ok(!isReactFunctionalComponent(Comp));
+  t.ok(isReactFunctionalComponent(fn));
+  t.ok(isReactFunctionalComponent(arrow));
+  t.ok(!isReactFunctionalComponent(''));
+  t.ok(!isReactFunctionalComponent(null));
+  t.ok(!isReactFunctionalComponent(undefined));
+  t.end();
+});

--- a/src/async/utils/isReactCompositeComponent.js
+++ b/src/async/utils/isReactCompositeComponent.js
@@ -10,6 +10,7 @@ export default function isReactCompositeComponent(type: mixed) {
   if (
     type != null &&
     typeof type === 'function' &&
+    type.prototype != null &&
     typeof type.prototype.render === 'function'
   ) {
     return true;

--- a/src/async/utils/isReactFunctionalComponent.js
+++ b/src/async/utils/isReactFunctionalComponent.js
@@ -7,6 +7,10 @@
  */
 
 export default function isReactFunctionalComponent(type: mixed) {
-  if (typeof type === 'function' && !type.prototype.render) return true;
+  if (
+    typeof type === 'function' &&
+    (type.prototype == null || !type.prototype.render)
+  )
+    return true;
   return false;
 }

--- a/src/async/utils/isReactFunctionalComponent.js
+++ b/src/async/utils/isReactFunctionalComponent.js
@@ -6,13 +6,7 @@
  * @flow
  */
 
-export default function isReactCompositeComponent(type: mixed) {
-  if (
-    type != null &&
-    typeof type === 'function' &&
-    typeof type.prototype.render === 'function'
-  ) {
-    return true;
-  }
+export default function isReactFunctionalComponent(type: mixed) {
+  if (typeof type === 'function' && !type.prototype.render) return true;
   return false;
 }


### PR DESCRIPTION
If `prepare` receives something that is not a well-formed React element, it barfs with an unhelpful error (type is not a function)

It should instead throw an error about what is most likely to cause the error to happen