### PR TITLE
Remove documented middleware API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,16 +193,6 @@ const hoc: HOC = ProvidedHOC.create(
 - `mapProvidesToProps: Object => Object` - Optional. Defaults to `provides => ({[name]: provides})`. Determines what props are exposed by the HOC
 - returns `hoc: Component => Component`
 
-#### middleware
-
-```js
-import {middleware} from 'fusion-react';
-```
-
-A middleware that adds a `PrepareProvider` to the React tree.
-
-Consider using [`fusion-react`](https://github.com/fusionjs/fusion-react) instead of setting up React and registering this middleware manually, since that package does all of that for you.
-
 #### split
 
 ```js


### PR DESCRIPTION
Seems that this was removed in https://github.com/fusionjs/fusion-react/commit/a0559c57f18e90b23603eb0ae49864dc5f1f6462#diff-07515936d1c7795189d1d214e39db5c5

This is possibly a breaking change, but not sure if anyone was using this.