### PR TITLE
Fix warning `Can't call setState on a component that is not yet mounted`

### DIFF
--- a/src/async/__tests__/__node__/prepare-render.node.js
+++ b/src/async/__tests__/__node__/prepare-render.node.js
@@ -725,6 +725,7 @@ tape('Preparing a component using getDerivedStateFromProps', t => {
   let numChildRenders = 0;
   let numPrepares = 0;
   let numDerivedStateFromProps = 0;
+  let retainedState = false;
   class SimpleComponent extends Component<any, any> {
     constructor(props, context) {
       super(props, context);
@@ -736,6 +737,7 @@ tape('Preparing a component using getDerivedStateFromProps', t => {
       numConstructors++;
       this.state = {
         firstRender: true,
+        originalState: 'should remain',
       };
     }
 
@@ -746,9 +748,13 @@ tape('Preparing a component using getDerivedStateFromProps', t => {
         someNewKey: [1, 2, 3],
       };
     }
+    componentWillMount() {
+      throw new Error('Should not be called when gDSFP is defined');
+    }
 
     render() {
       numRenders++;
+      retainedState = this.state.originalState === 'should remain';
       return (
         <div>
           {this.state.someNewKey.map((item, key) => (
@@ -782,6 +788,7 @@ tape('Preparing a component using getDerivedStateFromProps', t => {
   const p = prepare(app);
   t.ok(p instanceof Promise, 'prepare returns a promise');
   p.then(() => {
+    t.equal(retainedState, true, 'gDSFP does not overwrite state');
     t.equal(numPrepares, 1, 'runs the prepare function once');
     t.equal(numConstructors, 1, 'constructs SimpleComponent once');
     t.equal(numRenders, 1, 'renders SimpleComponent once');

--- a/src/async/__tests__/__node__/prepare-render.node.js
+++ b/src/async/__tests__/__node__/prepare-render.node.js
@@ -748,6 +748,7 @@ tape('Preparing a component using getDerivedStateFromProps', t => {
         someNewKey: [1, 2, 3],
       };
     }
+    // eslint-disable-next-line react/no-deprecated
     componentWillMount() {
       throw new Error('Should not be called when gDSFP is defined');
     }

--- a/src/async/prepare.js
+++ b/src/async/prepare.js
@@ -26,16 +26,20 @@ function renderCompositeElementInstance(instance) {
   );
 
   if (instance.constructor && instance.constructor.getDerivedStateFromProps) {
-    instance.state = instance.constructor.getDerivedStateFromProps(
-      instance.props,
-      instance.state
-    );
-  }
-
-  if (instance.componentWillMount) {
-    instance.componentWillMount();
-  } else if (instance.UNSAFE_componentWillMount) {
-    instance.UNSAFE_componentWillMount();
+    instance.state = {
+      ...instance.state,
+      ...instance.constructor.getDerivedStateFromProps(
+        instance.props,
+        instance.state
+      ),
+    };
+  } else {
+    // see https://github.com/reactjs/react-lifecycles-compat/blob/0a02b805fcf119128d1a9244e71ea7077e2cdcc0/index.js#L114
+    if (instance.componentWillMount) {
+      instance.componentWillMount();
+    } else if (instance.UNSAFE_componentWillMount) {
+      instance.UNSAFE_componentWillMount();
+    }
   }
   const children = instance.render();
   return [children, childContext];


### PR DESCRIPTION
Fixes #179 

Previously, our `renderCompositeElementInstance` function deviated from React semantics in two ways:

- we were overwriting the initial state w/ the output of `getDerivedStateFromProps` instead of augmenting it
- it would call `componentWillMount` regardless of whether `getDerivedStateFromProps` is defined. It should only be called if it's not defined[*](https://github.com/reactjs/react-lifecycles-compat/blob/0a02b805fcf119128d1a9244e71ea7077e2cdcc0/index.js#L114)

This PR aligns renderCompositeElementInstance with React semantics to address the two discrepancies above