### PR TITLE
Support portals

### DIFF
--- a/src/async/__tests__/__browser__/prepare-render.browser.js
+++ b/src/async/__tests__/__browser__/prepare-render.browser.js
@@ -1,0 +1,62 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-disable react/no-multi-comp */
+import tape from 'tape-cup';
+import React, {Component} from 'react';
+import {createPortal} from 'react-dom';
+import Enzyme, {shallow} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {prepare, prepared} from '../../index.js';
+
+Enzyme.configure({adapter: new Adapter()});
+
+tape('Preparing w/ Portal', t => {
+  const portal = document.createElement('div');
+  document.body.appendChild(portal);
+
+  let numConstructors = 0;
+  let numRenders = 0;
+  let numChildRenders = 0;
+
+  class SimpleComponent extends Component<any> {
+    constructor(props, context) {
+      super(props, context);
+      t.equal(
+        context.__IS_PREPARE__,
+        true,
+        'sets __IS_PREPARE__ to true in context'
+      );
+      numConstructors++;
+    }
+    render() {
+      numRenders++;
+      return createPortal(this.props.children, portal);
+    }
+  }
+  function SimplePresentational() {
+    numChildRenders++;
+    return <div>Hello World</div>;
+  }
+  const app = (
+    <SimpleComponent>
+      <SimplePresentational />
+    </SimpleComponent>
+  );
+  const p = prepare(app);
+  t.ok(p instanceof Promise, 'prepare returns a promise');
+  p.then(() => {
+    t.equal(numConstructors, 1, 'constructs SimpleComponent once');
+    t.equal(numRenders, 1, 'renders SimpleComponent once');
+    t.equal(numChildRenders, 1, 'renders SimplePresentational once');
+
+    document.body.removeChild(portal);
+
+    t.end();
+  });
+});

--- a/src/async/__tests__/__browser__/prepare-render.browser.js
+++ b/src/async/__tests__/__browser__/prepare-render.browser.js
@@ -6,13 +6,14 @@
  * @flow
  */
 
+/* eslint-env browser */
 /* eslint-disable react/no-multi-comp */
 import tape from 'tape-cup';
 import React, {Component} from 'react';
 import {createPortal} from 'react-dom';
-import Enzyme, {shallow} from 'enzyme';
+import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import {prepare, prepared} from '../../index.js';
+import {prepare} from '../../index.js';
 
 Enzyme.configure({adapter: new Adapter()});
 

--- a/src/async/__tests__/index.browser.js
+++ b/src/async/__tests__/index.browser.js
@@ -1,0 +1,14 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-env node */
+import './__browser__/prepare-render.browser.js';
+
+process.on('unhandledRejection', e => {
+  throw e;
+});

--- a/src/async/prepare.js
+++ b/src/async/prepare.js
@@ -12,6 +12,7 @@ import {
   isContextConsumer,
   isContextProvider,
   isForwardRef,
+  isPortal,
 } from 'react-is';
 
 import isReactCompositeComponent from './utils/isReactCompositeComponent';
@@ -92,6 +93,8 @@ function prepareElement(element, context) {
       }
       return renderCompositeElementInstance(instance);
     });
+  } else if (isPortal(element)) {
+    return Promise.resolve([element.children, context]);
   } else {
     throw new TypeError(
       `Invalid React element type. Must be a string, a function or a subclass of React.Component. ` +


### PR DESCRIPTION
Fixed #176

Portals are not technically supported server-side, but `prepare` should still not throw if they are used client-side