### PR TITLE
Run argument validation early

### DIFF
--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -33,3 +33,14 @@ test('app api', async t => {
     t.end();
   }
 });
+
+test('throw on non-element root', async t => {
+  t.throws(
+    () =>
+      new App(function() {
+        return null;
+      }),
+    'Passing a component instead of an element throws'
+  );
+  t.end();
+});

--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -35,12 +35,11 @@ test('app api', async t => {
 });
 
 test('throw on non-element root', async t => {
-  t.throws(
-    () =>
-      new App(function() {
-        return null;
-      }),
-    'Passing a component instead of an element throws'
-  );
+  t.throws(() => {
+    // $FlowFixMe
+    new App(function() {
+      return null;
+    });
+  }, 'Passing a component instead of an element throws');
   t.end();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ declare var __NODE__: Boolean;
 
 export default class App extends FusionApp {
   constructor(root: React.Element<*>, render: ?(React.Element<*>) => any) {
+    if (!React.isValidElement(root)) throw new Error('Invalid React element');
     const renderer = createPlugin({
       deps: {
         criticalChunkIds: CriticalChunkIdsToken.optional,

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,10 @@ declare var __NODE__: Boolean;
 
 export default class App extends FusionApp {
   constructor(root: React.Element<*>, render: ?(React.Element<*>) => any) {
-    if (!React.isValidElement(root)) throw new Error('Invalid React element');
+    if (!React.isValidElement(root))
+      throw new Error(
+        'Invalid React element. Ensure your root element is a React.Element and not a React.Component'
+      );
     const renderer = createPlugin({
       deps: {
         criticalChunkIds: CriticalChunkIdsToken.optional,


### PR DESCRIPTION
Rationale: when erroneously calling `new App(SomeComponent)` instead of `new App(<SomeComponent />)`, an error gets thrown from either `prepare` or a random `React.Children.only` call if such a thing exists in the Provider tree setup by the DI system. The error is extremely difficult to debug and does not provide any hint towards the source of the problem.

This problem has appeared a number of times in internal Uber migrations and wasted a lot of developer time.

This PR adds a validation check in the `new App` call, in order to throw a more debuggable/actionable error in this situation.
