### PR TITLE
Validate that async component contains a default export

### DIFF
--- a/src/async/split.js
+++ b/src/async/split.js
@@ -76,6 +76,9 @@ export default function withAsyncComponent({
         .then(([asyncComponent]) => {
           // Note: .default is toolchain specific, breaks w/ CommonJS exports
           AsyncComponent = asyncComponent.default;
+          if (AsyncComponent === undefined) {
+            throw new Error('Bundle does not contain a default export');
+          }
         })
         .catch(err => {
           error = err;


### PR DESCRIPTION
In case you forget to export async components as default the load hangs forever. This is clearly a programmer error so throwing will help debugging.