### PR TITLE
Allow for non-async usage for 'prepared'

### DIFF
--- a/src/async/__tests__/__node__/prepare-render.node.js
+++ b/src/async/__tests__/__node__/prepare-render.node.js
@@ -265,7 +265,7 @@ tape('Preparing an app with sibling async components', t => {
       'test',
       'passes props through to prepared component correctly'
     );
-    return Promise.resolve();
+    return;
   })(SimpleComponent);
   const app = (
     <div>

--- a/src/async/index.js
+++ b/src/async/index.js
@@ -21,7 +21,7 @@ const prepareTyped: (
 ) => Promise<React.ComponentType<any>> = prepare;
 
 const preparedTyped: (
-  sideEffect: (props: Object, context: Object) => Promise<any>,
+  sideEffect: (props: Object, context: Object) => Promise<any> | any,
   opts?: {
     defer?: boolean,
     boundary?: boolean,


### PR DESCRIPTION
Resolves [WPT-1650](https://jeng.uberinternal.com/browse/WPT-1650):

```
yarn run v1.9.4
$ flow check
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/components/profile/profile-page.js:43:5

Cannot call prepared with function bound to sideEffect because undefined [1] is incompatible with Promise [2] in the
return value.

     src/components/profile/profile-page.js
     39│   }),
     40│   withUser,
     41│   withUserCity,
     42│   prepared(props => {
 [1] 43│     return; //non-async
     44│   })
     45│ );
     46│
     47│ export type {Props};

     node_modules/fusion-react/src/async/index.js
 [2] 24│   sideEffect: (props: Object, context: Object) => Promise<any>,



Found 1 error
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```