### PR TITLE
Release v1.3.6-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-react",
   "description": "FusionJS entry point for React universal rendering",
-  "version": "1.3.5",
+  "version": "1.3.6-0",
   "license": "MIT",
   "repository": "fusionjs/fusion-react",
   "files": [


### PR DESCRIPTION
- Allow for non-async usage for 'prepared' ([#207](https://github.com/fusionjs/fusion-react/pull/207))