### PR TITLE
Call prepare in browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,19 +35,16 @@ export default class App extends FusionApp {
       },
       provides() {
         return (el: React.Element<*>) => {
-          if (__NODE__) {
-            return prepare(el).then(() => {
-              if (render) {
-                return render(el);
-              }
-              return serverRender(el);
-            });
-          } else {
+          return prepare(el).then(() => {
             if (render) {
               return render(el);
             }
-            return clientRender(el);
-          }
+            if (__NODE__) {
+              return serverRender(el);
+            } else {
+              return clientRender(el);
+            }
+          });
         };
       },
       middleware({criticalChunkIds}) {


### PR DESCRIPTION
This fixes a regression in fusion-plugin-rpc-redux-react tests.

As per internal discussion, the prepare call was removed in browser code path because it was assumed to no longer be needed, but this assumption only took into consideration bundle splitting, and not generic usage of prepared. Not calling `prepare` in browser effectively treats `prepared` as `{defer: true}` on the client always.